### PR TITLE
Add: Service, Repository 레이어 + Entity, DTO 생성, 일정 생성 API 구현

### DIFF
--- a/src/main/java/com/example/schedulerapp/SchedulerAppDevelopProjectApplication.java
+++ b/src/main/java/com/example/schedulerapp/SchedulerAppDevelopProjectApplication.java
@@ -2,7 +2,9 @@ package com.example.schedulerapp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class SchedulerAppDevelopProjectApplication {
 

--- a/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
@@ -1,0 +1,34 @@
+package com.example.schedulerapp.controller;
+
+import com.example.schedulerapp.dto.scheduleDto.CreateScheduleRequestDto;
+import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
+import com.example.schedulerapp.service.ScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/schedules")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    @PostMapping
+    public ResponseEntity<ScheduleResponseDto> saveSchedule(@RequestBody CreateScheduleRequestDto requestDto) {
+
+        ScheduleResponseDto scheduleResponseDto =
+                scheduleService.saveSchedule(
+                        requestDto.getUsername(),
+                        requestDto.getTitle(),
+                        requestDto.getContents()
+                );
+
+        return new ResponseEntity<>(scheduleResponseDto, HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/com/example/schedulerapp/dto/scheduleDto/CreateScheduleRequestDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/scheduleDto/CreateScheduleRequestDto.java
@@ -1,0 +1,19 @@
+package com.example.schedulerapp.dto.scheduleDto;
+
+import lombok.Getter;
+
+@Getter
+public class CreateScheduleRequestDto {
+
+    private final String username;
+
+    private final String title;
+
+    private final String contents;
+
+    public CreateScheduleRequestDto(String username, String title, String contents) {
+        this.username = username;
+        this.title = title;
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/example/schedulerapp/dto/scheduleDto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/scheduleDto/ScheduleResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.schedulerapp.dto.scheduleDto;
+
+import lombok.Getter;
+
+@Getter
+public class ScheduleResponseDto {
+
+    private final Long id;
+
+    private final String title;
+
+    private final String contents;
+
+    public ScheduleResponseDto(Long id, String title, String contents) {
+        this.id = id;
+        this.title = title;
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/example/schedulerapp/entity/BaseEntity.java
+++ b/src/main/java/com/example/schedulerapp/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.example.schedulerapp.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/example/schedulerapp/entity/Schedule.java
+++ b/src/main/java/com/example/schedulerapp/entity/Schedule.java
@@ -1,10 +1,11 @@
 package com.example.schedulerapp.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.Getter;
 
+@Getter
+@Entity
+@Table(name = "schedule")
 public class Schedule extends BaseEntity {
 
     @Id
@@ -20,4 +21,12 @@ public class Schedule extends BaseEntity {
     @Column(columnDefinition = "longtext")
     private String contents;
 
+    public Schedule() {
+    }
+
+    public Schedule(String username, String title, String contents) {
+        this.username = username;
+        this.title = title;
+        this.contents = contents;
+    }
 }

--- a/src/main/java/com/example/schedulerapp/entity/Schedule.java
+++ b/src/main/java/com/example/schedulerapp/entity/Schedule.java
@@ -1,0 +1,23 @@
+package com.example.schedulerapp.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+public class Schedule extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "longtext")
+    private String contents;
+
+}

--- a/src/main/java/com/example/schedulerapp/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/schedulerapp/repository/ScheduleRepository.java
@@ -1,0 +1,8 @@
+package com.example.schedulerapp.repository;
+
+import com.example.schedulerapp.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/src/main/java/com/example/schedulerapp/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleService.java
@@ -1,0 +1,8 @@
+package com.example.schedulerapp.service;
+
+import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
+
+public interface ScheduleService {
+
+    public ScheduleResponseDto saveSchedule(String username, String title, String contents);
+}

--- a/src/main/java/com/example/schedulerapp/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleService.java
@@ -4,5 +4,5 @@ import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
 
 public interface ScheduleService {
 
-    public ScheduleResponseDto saveSchedule(String username, String title, String contents);
+    ScheduleResponseDto saveSchedule(String username, String title, String contents);
 }

--- a/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
@@ -1,0 +1,25 @@
+package com.example.schedulerapp.service;
+
+import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
+import com.example.schedulerapp.entity.Schedule;
+import com.example.schedulerapp.repository.ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleServiceJPA implements ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+
+
+    @Override
+    public ScheduleResponseDto saveSchedule(String username, String title, String contents) {
+
+        Schedule schedule = new Schedule(username, title, contents);
+
+        scheduleRepository.save(schedule);
+
+        return new ScheduleResponseDto(schedule.getId(), schedule.getTitle(), schedule.getContents());
+    }
+}


### PR DESCRIPTION
89b62f1d7d895a2d9831073f4de070c728c92f40, e4a9d998a0b0038b1ee9cfff451beed0110897b8, b17ce1ffb84720f29f926e7442f4e52e3d671cfd
- JPA Auditing 활용 > 생성일, 수정일을 자동 처리 Entity 구현 (BaseEntity)
- Schedule Entity 구현

eb57bf2d30f0e41968571e6794e9535fa3594c27, fdf767cfb41cb69a13173ea066c26ff40670acaf
- DTO 생성
 -- 일정 생성 요청 DTO (CreateScheduleRequestDto)
 -- 일정 응답 DTO (ScheduleResponseDto)

77e91169c5447df6b2ea7d0f34ea95e7e3170715
- Repository 레이어 생성 > JpaRepository 상속 

d3afe92c8a81b70626ed5681d65c68e779820a12, cb6701ced5ced34878e4ac1dff5b0279b6a265ed
- Service 레이어 생성
- 일정 생성 기능 구현

9b63fbc7951e5a20221d56bc0791d9c3960cde40
- Controller 레이어 생성
- 일정 생성 기능 구현