### PR TITLE
Feat: 일정 CRUD - 전체 일정 조회 API 구현

### DIFF
--- a/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
@@ -6,10 +6,9 @@ import com.example.schedulerapp.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/schedules")
@@ -29,6 +28,13 @@ public class ScheduleController {
                 );
 
         return new ResponseEntity<>(scheduleResponseDto, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ScheduleResponseDto>> findAll () {
+        List<ScheduleResponseDto> scheduleResponseDtoList = scheduleService.findAll();
+
+        return new ResponseEntity<>(scheduleResponseDtoList, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/schedulerapp/dto/scheduleDto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/scheduleDto/ScheduleResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.schedulerapp.dto.scheduleDto;
 
+import com.example.schedulerapp.entity.Schedule;
 import lombok.Getter;
 
 @Getter
@@ -11,9 +12,16 @@ public class ScheduleResponseDto {
 
     private final String contents;
 
-    public ScheduleResponseDto(Long id, String title, String contents) {
+    private final String username;
+
+    public ScheduleResponseDto(Long id, String title, String contents, String username) {
         this.id = id;
         this.title = title;
         this.contents = contents;
+        this.username = username;
+    }
+
+    public static ScheduleResponseDto toDto (Schedule schedule) {
+        return new ScheduleResponseDto(schedule.getId(), schedule.getTitle(), schedule.getContents(), schedule.getUsername());
     }
 }

--- a/src/main/java/com/example/schedulerapp/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleService.java
@@ -2,7 +2,11 @@ package com.example.schedulerapp.service;
 
 import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
 
+import java.util.List;
+
 public interface ScheduleService {
 
     ScheduleResponseDto saveSchedule(String username, String title, String contents);
+
+    List<ScheduleResponseDto> findAll();
 }

--- a/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
@@ -6,6 +6,8 @@ import com.example.schedulerapp.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ScheduleServiceJPA implements ScheduleService {
@@ -13,6 +15,13 @@ public class ScheduleServiceJPA implements ScheduleService {
     private final ScheduleRepository scheduleRepository;
 
 
+    /**
+     * 일정 생성 API
+     * @param username 작성 유저명
+     * @param title 할 일 제목
+     * @param contents 할 일 내용
+     * @return schedule Entity 의 id, title, contents 값을 ResponseDto 로 반환
+     */
     @Override
     public ScheduleResponseDto saveSchedule(String username, String title, String contents) {
 
@@ -20,6 +29,12 @@ public class ScheduleServiceJPA implements ScheduleService {
 
         scheduleRepository.save(schedule);
 
-        return new ScheduleResponseDto(schedule.getId(), schedule.getTitle(), schedule.getContents());
+        return new ScheduleResponseDto(schedule.getId(), schedule.getTitle(), schedule.getContents(), schedule.getUsername());
+    }
+
+
+    @Override
+    public List<ScheduleResponseDto> findAll() {
+        return scheduleRepository.findAll().stream().map(ScheduleResponseDto::toDto).toList();
     }
 }


### PR DESCRIPTION
응답 DTO 코드 추가: 518b4f499c4744b94cab0baeac340a934e9bd264
- username도 결과 값으로 반환되도록 username 속성 추가
- toDto 메서드 구현 > Entity를 Dto로 변환되도록 함

일정 전체 조회 기능 구현
- Controller, Service 레이어 내 기능 구현
- List 타입으로 반환, 데이터가 없을 경우 빈 배열로 조회
- 정상 조회 시 Http 상태코드는 200 OK 로 반환