### PR TITLE
Add: Entity mapping, Refactor: 일정 생성 API 리팩토링

### DIFF
--- a/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
@@ -24,9 +24,9 @@ public class ScheduleController {
 
         ScheduleResponseDto scheduleResponseDto =
                 scheduleService.saveSchedule(
-                        requestDto.getUsername(),
                         requestDto.getTitle(),
-                        requestDto.getContents()
+                        requestDto.getContents(),
+                        requestDto.getUsername()
                 );
 
         return new ResponseEntity<>(scheduleResponseDto, HttpStatus.CREATED);

--- a/src/main/java/com/example/schedulerapp/dto/scheduleDto/CreateScheduleRequestDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/scheduleDto/CreateScheduleRequestDto.java
@@ -11,9 +11,9 @@ public class CreateScheduleRequestDto {
 
     private final String contents;
 
-    public CreateScheduleRequestDto(String username, String title, String contents) {
-        this.username = username;
+    public CreateScheduleRequestDto(String title, String contents, String username) {
         this.title = title;
         this.contents = contents;
+        this.username = username;
     }
 }

--- a/src/main/java/com/example/schedulerapp/dto/scheduleDto/UpdateScheduleRequestDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/scheduleDto/UpdateScheduleRequestDto.java
@@ -1,18 +1,19 @@
 package com.example.schedulerapp.dto.scheduleDto;
 
+import com.example.schedulerapp.entity.User;
 import lombok.Getter;
 
 @Getter
 public class UpdateScheduleRequestDto {
 
-    private final String username;
+    private final User user;
 
     private final String title;
 
     private final String contents;
 
-    public UpdateScheduleRequestDto(String username, String title, String contents) {
-        this.username = username;
+    public UpdateScheduleRequestDto(String title, String contents, User user) {
+        this.user = user;
         this.title = title;
         this.contents = contents;
     }

--- a/src/main/java/com/example/schedulerapp/entity/Schedule.java
+++ b/src/main/java/com/example/schedulerapp/entity/Schedule.java
@@ -2,6 +2,7 @@ package com.example.schedulerapp.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 @Entity
@@ -12,8 +13,8 @@ public class Schedule extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private String username;
+//    @Column(nullable = false)
+//    private String username;
 
     @Column(nullable = false)
     private String title;
@@ -21,18 +22,24 @@ public class Schedule extends BaseTimeEntity {
     @Column(columnDefinition = "longtext")
     private String contents;
 
+    @Setter
+    @ManyToOne // 여러 일정이 하나의 유저와 연결
+    @JoinColumn(name = "user_id") // 실제 DB 에서 FK를 user_id로 설정
+    private User user;
+
+
     public Schedule() {
     }
 
-    public Schedule(String username, String title, String contents) {
-        this.username = username;
+    public Schedule(String title, String contents) {
         this.title = title;
         this.contents = contents;
     }
 
-    public void updateSchedule(String username, String title, String contents){
-        this.username = username;
+    public void updateSchedule(User user, String title, String contents){
+        this.user = user;
         this.title = title;
         this.contents = contents;
     }
+
 }

--- a/src/main/java/com/example/schedulerapp/entity/User.java
+++ b/src/main/java/com/example/schedulerapp/entity/User.java
@@ -4,6 +4,8 @@ package com.example.schedulerapp.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @Entity
 @Table(name = "users")
@@ -17,6 +19,10 @@ public class User extends BaseTimeEntity {
     private String name;
 
     private String email;
+
+    // 유저와 관련된 일정들을 한번에 조회 목적 > User -> Schedule 방향 관계 설정
+    @OneToMany(mappedBy = "user")
+    private List<Schedule> schedules; // 하나의 유저가 여러 개의 일정과 연관됨
 
     public User() {
     }

--- a/src/main/java/com/example/schedulerapp/repository/UserRepository.java
+++ b/src/main/java/com/example/schedulerapp/repository/UserRepository.java
@@ -5,9 +5,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 
     default User findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Does not exist id = " + id));
+    }
+
+    Optional<User> findUserByName(String username);
+
+    default User findUserByUsernameOrElseThrow(String username) {
+        return findUserByName(username).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Does not exist id = " + username));
     }
 }

--- a/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
@@ -4,7 +4,9 @@ import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
 import com.example.schedulerapp.dto.scheduleDto.ScheduleTimeIncludedResponseDto;
 import com.example.schedulerapp.dto.scheduleDto.UpdateScheduleRequestDto;
 import com.example.schedulerapp.entity.Schedule;
+import com.example.schedulerapp.entity.User;
 import com.example.schedulerapp.repository.ScheduleRepository;
+import com.example.schedulerapp.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +18,7 @@ import java.util.List;
 public class ScheduleServiceJPA implements ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
+    private final UserRepository userRepository;
 
 
     /**
@@ -26,13 +29,16 @@ public class ScheduleServiceJPA implements ScheduleService {
      * @return schedule Entity 의 id, title, contents 값을 ResponseDto 로 반환
      */
     @Override
-    public ScheduleResponseDto saveSchedule(String username, String title, String contents) {
+    public ScheduleResponseDto saveSchedule(String title, String contents, String username) {
 
-        Schedule schedule = new Schedule(username, title, contents);
+        User findUser = userRepository.findUserByUsernameOrElseThrow(username);
 
-        scheduleRepository.save(schedule);
+        Schedule schedule = new Schedule(title, contents);
+        schedule.setUser(findUser);
 
-        return new ScheduleResponseDto(schedule.getId(), schedule.getTitle(), schedule.getContents(), schedule.getUsername());
+        Schedule savedSchedule = scheduleRepository.save(schedule);
+
+        return new ScheduleResponseDto(savedSchedule.getId(), savedSchedule.getTitle(), savedSchedule.getContents(), savedSchedule.getUser().getName());
     }
 
 
@@ -45,7 +51,7 @@ public class ScheduleServiceJPA implements ScheduleService {
     public ScheduleTimeIncludedResponseDto findByIdSchedule(Long id) {
         Schedule findSchedule = scheduleRepository.findByIdOrElseThrow(id);
 
-        return new ScheduleTimeIncludedResponseDto(findSchedule.getId(), findSchedule.getTitle(), findSchedule.getContents(), findSchedule.getUsername(), findSchedule.getCreatedAt(), findSchedule.getModifiedAt());
+        return new ScheduleTimeIncludedResponseDto(findSchedule.getId(), findSchedule.getTitle(), findSchedule.getContents(), findSchedule.getUser(), findSchedule.getCreatedAt(), findSchedule.getModifiedAt());
     }
 
     @Transactional
@@ -53,9 +59,9 @@ public class ScheduleServiceJPA implements ScheduleService {
     public ScheduleResponseDto updatedByIdSchedule(Long id, UpdateScheduleRequestDto requestDto) {
         Schedule findSchedule = scheduleRepository.findByIdOrElseThrow(id);
 
-        findSchedule.updateSchedule(requestDto.getUsername(), requestDto.getTitle(), requestDto.getContents());
+        findSchedule.updateSchedule(requestDto.getUser(), requestDto.getTitle(), requestDto.getContents());
 
-        return new ScheduleResponseDto(findSchedule.getId(), findSchedule.getTitle(), findSchedule.getContents(), findSchedule.getUsername());
+        return new ScheduleResponseDto(findSchedule.getId(), findSchedule.getTitle(), findSchedule.getContents(), findSchedule.getUser().getName());
     }
 
     @Override


### PR DESCRIPTION
(Add) 연관 관계 매핑
- Schedule 엔티티와 User 엔티티의 연관 관계 설정(양방향)
 -- Schedule: user_id 컬럼 생성 + FK 설정, @ManyToOne 설정
 -- User: @OneToMany 어노테이션 설정 + mappedBy 설정
    -->> Schedule 엔티티를 List로 객체화 > 유저와 관련된 일정을 한번에 조회하기 위함
- Schedule 엔티티의 username 속성 삭제 > 이후 유저 식별자는 user_id를 활용
- 커밋: eab67ff67b97412889907c4a2b5600e965d76aba

(Add) User 레퍼지토리 레이어에서 유저 객체를 username 으로 찾는 코드 추가
- 매개변수로 받은 username 을 통해 User 레퍼지토리 내 User 객체를 찾기
 -- 있으면 정상적으로 User 객체를 반환
 -- 없으면 예외 처리 > 404 NOT FOUND 오류 코드 반환
- 커밋: 167803d0db523c7ca636837a5027790a15db2b59

(Refactor) Service 레이어 > 일정 생성 API 리팩토링
- DTO 로 요청받은 username > user 레퍼지토리에서 해당 username 에 해당하는 User 객체 확인
- 없으면 > 404 NOT FOUND 상태 코드 반환 (이후 로직 X)
- 있으면 > 해당 User 객체를 Setter를 활용하여 설정 > savedSchedule에 저장 후 해당 데이터를 담은 응답 DTO 객체를 생성 후 반환
- 커밋: e56a3e8cd50c41e2dddc84e89310c1dd9cb199f3

(Refactor) 일정 생성 관련 메서드 매개변수 순서 조정
- 다른 메서드들과 매개변수 위치 통일을 위해 일부 코드 순서 조정
- 커밋: 2c437f58370951618b047b8aa7bb43902e4f2f88

