### PR TITLE
Refactor: 연관 관계 매핑 > 일정 수정 API 코드 리펙토링

### DIFF
--- a/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
@@ -51,7 +51,13 @@ public class ScheduleController {
             @PathVariable Long id,
             @RequestBody UpdateScheduleRequestDto requestDto
     ) {
-        ScheduleResponseDto scheduleResponseDto = scheduleService.updatedByIdSchedule(id, requestDto);
+        ScheduleResponseDto scheduleResponseDto =
+                scheduleService.updatedByIdSchedule(
+                        id,
+                        requestDto.getTitle(),
+                        requestDto.getContents(),
+                        requestDto.getUsername()
+                );
 
         return new ResponseEntity<>(scheduleResponseDto, HttpStatus.OK);
     }

--- a/src/main/java/com/example/schedulerapp/dto/scheduleDto/UpdateScheduleRequestDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/scheduleDto/UpdateScheduleRequestDto.java
@@ -1,20 +1,19 @@
 package com.example.schedulerapp.dto.scheduleDto;
 
-import com.example.schedulerapp.entity.User;
 import lombok.Getter;
 
 @Getter
 public class UpdateScheduleRequestDto {
 
-    private final User user;
+    private final String username;
 
     private final String title;
 
     private final String contents;
 
-    public UpdateScheduleRequestDto(String title, String contents, User user) {
-        this.user = user;
+    public UpdateScheduleRequestDto(String title, String contents, String username) {
         this.title = title;
         this.contents = contents;
+        this.username = username;
     }
 }

--- a/src/main/java/com/example/schedulerapp/entity/Schedule.java
+++ b/src/main/java/com/example/schedulerapp/entity/Schedule.java
@@ -36,8 +36,7 @@ public class Schedule extends BaseTimeEntity {
         this.contents = contents;
     }
 
-    public void updateSchedule(User user, String title, String contents){
-        this.user = user;
+    public void updateSchedule(String title, String contents){
         this.title = title;
         this.contents = contents;
     }

--- a/src/main/java/com/example/schedulerapp/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleService.java
@@ -1,20 +1,19 @@
 package com.example.schedulerapp.service;
 
-import com.example.schedulerapp.dto.scheduleDto.ScheduleTimeIncludedResponseDto;
 import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
-import com.example.schedulerapp.dto.scheduleDto.UpdateScheduleRequestDto;
+import com.example.schedulerapp.dto.scheduleDto.ScheduleTimeIncludedResponseDto;
 
 import java.util.List;
 
 public interface ScheduleService {
 
-    ScheduleResponseDto saveSchedule(String username, String title, String contents);
+    ScheduleResponseDto saveSchedule(String title, String contents, String username);
 
     List<ScheduleTimeIncludedResponseDto> findAllSchedules();
 
     ScheduleTimeIncludedResponseDto findByIdSchedule(Long id);
 
-    ScheduleResponseDto updatedByIdSchedule(Long id, UpdateScheduleRequestDto requestDto);
+    ScheduleResponseDto updatedByIdSchedule(Long id, String title, String contents, String username);
 
     void deleteSchedule(Long id);
 }

--- a/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
@@ -2,7 +2,6 @@ package com.example.schedulerapp.service;
 
 import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
 import com.example.schedulerapp.dto.scheduleDto.ScheduleTimeIncludedResponseDto;
-import com.example.schedulerapp.dto.scheduleDto.UpdateScheduleRequestDto;
 import com.example.schedulerapp.entity.Schedule;
 import com.example.schedulerapp.entity.User;
 import com.example.schedulerapp.repository.ScheduleRepository;
@@ -56,10 +55,13 @@ public class ScheduleServiceJPA implements ScheduleService {
 
     @Transactional
     @Override
-    public ScheduleResponseDto updatedByIdSchedule(Long id, UpdateScheduleRequestDto requestDto) {
+    public ScheduleResponseDto updatedByIdSchedule(Long id, String title, String contents, String username) {
+
+        User findUser = userRepository.findUserByUsernameOrElseThrow(username);
         Schedule findSchedule = scheduleRepository.findByIdOrElseThrow(id);
 
-        findSchedule.updateSchedule(requestDto.getUser(), requestDto.getTitle(), requestDto.getContents());
+        findSchedule.setUser(findUser);
+        findSchedule.updateSchedule(title, contents);
 
         return new ScheduleResponseDto(findSchedule.getId(), findSchedule.getTitle(), findSchedule.getContents(), findSchedule.getUser().getName());
     }


### PR DESCRIPTION
기존 username 사용한 매개변수를 User 객체의 Getter(name) 를 활용하도록 코드 수정
- Schedule 객체 > updateSchedule 메서드 내 username 삭제
- 매개변수 순서 조정 > 다른 메서드와 동일한 순서로 맞춤
- 연관 관계 매핑 후 잘못된 매개변수 내용 (User user) 수정
- 커밋: 8f5c666fe5edb3280e6e4f239935d04658c31fab

기존 일정 수정 기능 수정
- 메서드 매개변수 수정 (requestDto -> 각각 요소로 분리)
- 요청 DTO 의 username 값을 가진 User 객체 찾는 코드 추가
- Schedule 객체에 DTO 의 username 값을 가진 User 객체 설정하는 코드 추가
- 커밋: 654d63f7223a244fc4229a2622c46efab6b123d6