### PR TITLE
Add: 댓글 삭제 API 구현

### DIFF
--- a/src/main/java/com/example/schedulerapp/controller/CommentController.java
+++ b/src/main/java/com/example/schedulerapp/controller/CommentController.java
@@ -41,4 +41,11 @@ public class CommentController {
 
         return new ResponseEntity<>(commentResponseDto, HttpStatus.OK);
     }
+
+    @DeleteMapping("/{scheduleId}/comment/{commentId}")
+    public ResponseEntity<Void> deleteCommentById(@PathVariable Long scheduleId, @PathVariable Long commentId) {
+        commentService.deleteCommentById(scheduleId, commentId);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/schedulerapp/service/CommentService.java
+++ b/src/main/java/com/example/schedulerapp/service/CommentService.java
@@ -14,4 +14,6 @@ public interface CommentService {
 
     CommentResponseDto updateCommentById(Long scheduleId, Long commentId, CommentRequestDto requestDto);
 
+    void deleteCommentById(Long scheduleId, Long commentId);
+
 }

--- a/src/main/java/com/example/schedulerapp/service/CommentServiceJPA.java
+++ b/src/main/java/com/example/schedulerapp/service/CommentServiceJPA.java
@@ -57,11 +57,25 @@ public class CommentServiceJPA implements CommentService {
         CommentEntity findComment = commentRepository.findByIdCommentOrElseThrow(commentId);
 
         if (!findComment.getSchedule().getId().equals(scheduleId)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The comment you are currently trying to edit is not a comment for this schedule.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Does not exist Comment");
         }
 
         findComment.updateComment(requestDto.getComment());
 
         return new CommentResponseDto(findComment.getId(), findComment.getComment(), findComment.getUser().getName());
+    }
+
+    @Override
+    public void deleteCommentById(Long scheduleId, Long commentId) {
+
+        scheduleRepository.findByIdOrElseThrow(scheduleId);
+
+        CommentEntity findComment = commentRepository.findByIdCommentOrElseThrow(commentId);
+
+        if (!findComment.getSchedule().getId().equals(scheduleId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Does not exist Comment");
+        }
+
+        commentRepository.delete(findComment);
     }
 }


### PR DESCRIPTION
- Controller: 요청 DTO 값을 서비스 레이어에 전달 + 댓글 수정 결과를 응답 DTO 타입으로 반환 (200 OK)
- Service: 컨트롤러 레이어에서 전달한 요청 DTO 값을 사용하여 댓글 삭제 기능 동작
> 삭제하려는 댓글의 위치 확인 절차 코드 구현
> - commentId 조회 > 해당 댓글이 소속된 일정 id와 요청받은 scheduleId와 일치하는지 비교
> - 일치: 정상 삭제 + 200 OK / 불일치: 400 BAD QUEST