### PR TITLE
Add: 일정 조회 기능 - 페이징 구현

### DIFF
--- a/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
@@ -1,12 +1,12 @@
 package com.example.schedulerapp.controller;
 
-import com.example.schedulerapp.dto.scheduleDto.CreateScheduleRequestDto;
-import com.example.schedulerapp.dto.scheduleDto.ScheduleTimeIncludedResponseDto;
-import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
-import com.example.schedulerapp.dto.scheduleDto.UpdateScheduleRequestDto;
+import com.example.schedulerapp.dto.scheduleDto.*;
 import com.example.schedulerapp.service.ScheduleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,6 +38,17 @@ public class ScheduleController {
         List<ScheduleTimeIncludedResponseDto> scheduleTimeIncludedResponseDto = scheduleService.findAllSchedules();
 
         return new ResponseEntity<>(scheduleTimeIncludedResponseDto, HttpStatus.OK);
+    }
+
+    @GetMapping("/paging")
+    public ResponseEntity<PageScheduleResponseDto<ScheduleTimeIncludedResponseDto>> getSchedules(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("modifiedAt").descending());
+        PageScheduleResponseDto<ScheduleTimeIncludedResponseDto> pagingResult = scheduleService.getSchedules(pageable);
+
+        return new ResponseEntity<>(pagingResult, HttpStatus.OK);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/example/schedulerapp/dto/scheduleDto/PageScheduleResponseDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/scheduleDto/PageScheduleResponseDto.java
@@ -1,0 +1,26 @@
+package com.example.schedulerapp.dto.scheduleDto;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class PageScheduleResponseDto<T> {
+    private final List<T> content;
+
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+    private final boolean last;
+
+    public PageScheduleResponseDto(Page<T> page) {
+        this.content = page.getContent();
+        this.page = page.getNumber();
+        this.size = page.getSize();
+        this.totalElements = page.getTotalElements();
+        this.totalPages = page.getTotalPages();
+        this.last = page.isLast();
+    }
+}

--- a/src/main/java/com/example/schedulerapp/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleService.java
@@ -1,7 +1,9 @@
 package com.example.schedulerapp.service;
 
+import com.example.schedulerapp.dto.scheduleDto.PageScheduleResponseDto;
 import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
 import com.example.schedulerapp.dto.scheduleDto.ScheduleTimeIncludedResponseDto;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -10,6 +12,8 @@ public interface ScheduleService {
     ScheduleResponseDto saveSchedule(String title, String contents, String username);
 
     List<ScheduleTimeIncludedResponseDto> findAllSchedules();
+
+    PageScheduleResponseDto<ScheduleTimeIncludedResponseDto> getSchedules(Pageable pageable);
 
     ScheduleTimeIncludedResponseDto findByIdSchedule(Long id);
 

--- a/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
@@ -1,5 +1,6 @@
 package com.example.schedulerapp.service;
 
+import com.example.schedulerapp.dto.scheduleDto.PageScheduleResponseDto;
 import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
 import com.example.schedulerapp.dto.scheduleDto.ScheduleTimeIncludedResponseDto;
 import com.example.schedulerapp.entity.Schedule;
@@ -7,6 +8,8 @@ import com.example.schedulerapp.entity.User;
 import com.example.schedulerapp.repository.ScheduleRepository;
 import com.example.schedulerapp.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,6 +47,14 @@ public class ScheduleServiceJPA implements ScheduleService {
     @Override
     public List<ScheduleTimeIncludedResponseDto> findAllSchedules() {
         return scheduleRepository.findAll().stream().map(ScheduleTimeIncludedResponseDto::toDto).toList();
+    }
+
+    @Override
+    public PageScheduleResponseDto<ScheduleTimeIncludedResponseDto> getSchedules(Pageable pageable) {
+        Page<Schedule> page = scheduleRepository.findAll(pageable);
+        Page<ScheduleTimeIncludedResponseDto> dtoPage = page.map(ScheduleTimeIncludedResponseDto::toDto);
+
+        return new PageScheduleResponseDto<>(dtoPage);
     }
 
     @Override


### PR DESCRIPTION
PageScheduleResponseDto
- 페이지 번호, 한 페이지에 담긴 데이터 수, 전체 데이터 수, 전체 페이지수 등을 담은 페이지 관련 응답 DTO 생성

Controller 레이어:
- page, size 를 파라미터로 전달
- 전달할 파라미터가 없을 경우 기본 값은 page=0, size=10 로 설정
- page, size 값으로 페이징 정보 생성, 수정일 기준으로 내림차순 정렬 설정
- 정상 조회 시 200 OK

Service 레이어:
- 레포지토리에서 조건에 맞는 일정 Entity 리스트를 Page 객체로 가져온 후 가져온 각 엔티티를 응답용 DTO 로 변환한 뒤반환