### PR TITLE
Refactor: 일정 생성 기능 수정

### DIFF
--- a/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulerapp/controller/ScheduleController.java
@@ -2,6 +2,7 @@ package com.example.schedulerapp.controller;
 
 import com.example.schedulerapp.dto.scheduleDto.*;
 import com.example.schedulerapp.service.ScheduleService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -21,14 +22,14 @@ public class ScheduleController {
     private final ScheduleService scheduleService;
 
     @PostMapping
-    public ResponseEntity<ScheduleResponseDto> saveSchedule(@RequestBody @Valid CreateScheduleRequestDto requestDto) {
+    public ResponseEntity<ScheduleResponseDto> saveSchedule(
+            @RequestBody @Valid CreateScheduleRequestDto requestDto,
+            HttpServletRequest servletRequest
+    ) {
 
-        ScheduleResponseDto scheduleResponseDto =
-                scheduleService.saveSchedule(
-                        requestDto.getTitle(),
-                        requestDto.getContents(),
-                        requestDto.getUsername()
-                );
+        Long userId = (Long) servletRequest.getSession(false).getAttribute("userId");
+
+        ScheduleResponseDto scheduleResponseDto = scheduleService.saveSchedule(requestDto, userId);
 
         return new ResponseEntity<>(scheduleResponseDto, HttpStatus.CREATED);
     }

--- a/src/main/java/com/example/schedulerapp/dto/scheduleDto/CreateScheduleRequestDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/scheduleDto/CreateScheduleRequestDto.java
@@ -1,15 +1,13 @@
 package com.example.schedulerapp.dto.scheduleDto;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
 
 @Getter
+@AllArgsConstructor
 public class CreateScheduleRequestDto {
-
-    @NotBlank
-    private final String username;
 
     @NotNull
     @Length(min=1, max=16)
@@ -17,9 +15,4 @@ public class CreateScheduleRequestDto {
 
     private final String contents;
 
-    public CreateScheduleRequestDto(String title, String contents, String username) {
-        this.title = title;
-        this.contents = contents;
-        this.username = username;
-    }
 }

--- a/src/main/java/com/example/schedulerapp/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleService.java
@@ -1,5 +1,6 @@
 package com.example.schedulerapp.service;
 
+import com.example.schedulerapp.dto.scheduleDto.CreateScheduleRequestDto;
 import com.example.schedulerapp.dto.scheduleDto.PageScheduleResponseDto;
 import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
 import com.example.schedulerapp.dto.scheduleDto.ScheduleTimeIncludedResponseDto;
@@ -9,7 +10,7 @@ import java.util.List;
 
 public interface ScheduleService {
 
-    ScheduleResponseDto saveSchedule(String title, String contents, String username);
+    ScheduleResponseDto saveSchedule(CreateScheduleRequestDto requestDto, Long userId);
 
     List<ScheduleTimeIncludedResponseDto> findAllSchedules();
 

--- a/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
@@ -1,5 +1,6 @@
 package com.example.schedulerapp.service;
 
+import com.example.schedulerapp.dto.scheduleDto.CreateScheduleRequestDto;
 import com.example.schedulerapp.dto.scheduleDto.PageScheduleResponseDto;
 import com.example.schedulerapp.dto.scheduleDto.ScheduleResponseDto;
 import com.example.schedulerapp.dto.scheduleDto.ScheduleTimeIncludedResponseDto;
@@ -31,11 +32,11 @@ public class ScheduleServiceJPA implements ScheduleService {
      * @return schedule Entity 의 id, title, contents 값을 ResponseDto 로 반환
      */
     @Override
-    public ScheduleResponseDto saveSchedule(String title, String contents, String username) {
+    public ScheduleResponseDto saveSchedule(CreateScheduleRequestDto requestDto, Long userId) {
 
-        User findUser = userRepository.findUserByUsernameOrElseThrow(username);
+        User findUser = userRepository.findByIdOrElseThrow(userId);
 
-        Schedule schedule = new Schedule(title, contents);
+        Schedule schedule = new Schedule(requestDto.getTitle(), requestDto.getContents());
         schedule.setUser(findUser);
 
         Schedule savedSchedule = scheduleRepository.save(schedule);


### PR DESCRIPTION
- 기존: 요청 DTO 의 username 값으로 일정 생성 시 DB 에 저장됨
- 수정: 일정 생성 로그인한 ID의 username 으로 저장되도록 수정

일정 생성 요청 DTO
- username 속성 삭제
> 로그인되어 있는 session 값을 이용 > 로그인된 유저의 username 으로 값을 저장할 것이기에 DTO 에서는 제외함

- Controller 레이어
> - saveSchedule 매개변수로 HttpServletRequest 추가
> - 서블릿의 getAttribute 를 통해 userId 값 얻은 후
> - 서비스 레이어에 요청 DTO 와 함께 전달

- Service 레이어
> - 매개변수로 받은 userId(Session 활용하여 얻은 값)로 user 찾은 후 기존의 일정 저장 로직 진행