### PR TITLE
Refactor: 댓글 수정 기능 리팩토링 > 로그인 유저 본인의 댓글만 수정할 수 있도록 코드 수정

### DIFF
--- a/src/main/java/com/example/schedulerapp/controller/CommentController.java
+++ b/src/main/java/com/example/schedulerapp/controller/CommentController.java
@@ -42,9 +42,16 @@ public class CommentController {
     }
 
     @PatchMapping("/{scheduleId}/comment/{commentId}")
-    public ResponseEntity<CommentResponseDto> updateCommentById(@PathVariable Long scheduleId, @PathVariable Long commentId, @RequestBody CommentRequestDto requestDto) {
+    public ResponseEntity<CommentResponseDto> updateCommentById(
+            @PathVariable Long scheduleId,
+            @PathVariable Long commentId,
+            @RequestBody CommentRequestDto requestDto,
+            HttpServletRequest servletRequest
+    ) {
 
-        CommentResponseDto commentResponseDto = commentService.updateCommentById(scheduleId, commentId, requestDto);
+        Long userId = (Long) servletRequest.getSession(false).getAttribute("userId");
+
+        CommentResponseDto commentResponseDto = commentService.updateCommentById(scheduleId, commentId, requestDto, userId);
 
         return new ResponseEntity<>(commentResponseDto, HttpStatus.OK);
     }

--- a/src/main/java/com/example/schedulerapp/service/CommentService.java
+++ b/src/main/java/com/example/schedulerapp/service/CommentService.java
@@ -12,7 +12,7 @@ public interface CommentService {
 
     List<CommentTimeIncludeResponseDto> findAllComments(Long scheduleId);
 
-    CommentResponseDto updateCommentById(Long scheduleId, Long commentId, CommentRequestDto requestDto);
+    CommentResponseDto updateCommentById(Long scheduleId, Long commentId, CommentRequestDto requestDto, Long userId);
 
     void deleteCommentById(Long scheduleId, Long commentId);
 

--- a/src/main/java/com/example/schedulerapp/service/CommentServiceJPA.java
+++ b/src/main/java/com/example/schedulerapp/service/CommentServiceJPA.java
@@ -51,14 +51,20 @@ public class CommentServiceJPA implements CommentService {
 
     @Transactional
     @Override
-    public CommentResponseDto updateCommentById(Long scheduleId, Long commentId, CommentRequestDto requestDto) {
+    public CommentResponseDto updateCommentById(Long scheduleId, Long commentId, CommentRequestDto requestDto, Long userId) {
 
-        scheduleRepository.findByIdOrElseThrow(scheduleId);
+        scheduleRepository.findByIdOrElseThrow(scheduleId); // 일정 조회
 
-        CommentEntity findComment = commentRepository.findByIdCommentOrElseThrow(commentId);
+        CommentEntity findComment = commentRepository.findByIdCommentOrElseThrow(commentId); // 댓글 조회
 
+        // 조회한 댓글이 조회한 일정에 속하는지 확인 절차
         if (!findComment.getSchedule().getId().equals(scheduleId)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Does not exist Comment");
+        }
+
+        // 댓글 작성자가 본인인지 확인 절차
+        if (!findComment.getUser().getId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You can only modify your own comment.");
         }
 
         findComment.updateComment(requestDto.getComment());


### PR DESCRIPTION
- 요청 DTO
> - username 속성 삭제

- Controller 레이어
> - updateByMyInfo 매개변수로 HttpServletRequest 추가
> - 서블릿의 getAttribute 를 통해 userId 값 얻은 후
> - 서비스 레이어에 요청 DTO 와 함께 전달

- Service 레이어
> - 매개변수로 받은 유저 식별자 Id(로그인 세션 정보)로 유저 정보 찾기
> - 찾은 유저 정보와 댓글 작성 데이터에 기록된 유저 정보와 비교
> - 일치: 댓글 수정 로직 진행 / 불일치: 403 FORBIDDEN 에러
> - 댓글 생성 시 요청 DTO 의 username 값 대신 로그인 유저의 username 을 저장하도록 수정