### PR TITLE
Refactor: 댓글 삭제 기능 리팩토링 > 로그인 유저 본인의 댓글만 삭제할 수 있도록 코드 수정

### DIFF
--- a/src/main/java/com/example/schedulerapp/controller/CommentController.java
+++ b/src/main/java/com/example/schedulerapp/controller/CommentController.java
@@ -57,8 +57,15 @@ public class CommentController {
     }
 
     @DeleteMapping("/{scheduleId}/comment/{commentId}")
-    public ResponseEntity<Void> deleteCommentById(@PathVariable Long scheduleId, @PathVariable Long commentId) {
-        commentService.deleteCommentById(scheduleId, commentId);
+    public ResponseEntity<Void> deleteCommentById(
+            @PathVariable Long scheduleId,
+            @PathVariable Long commentId,
+            HttpServletRequest servletRequest
+    ) {
+
+        Long userId = (Long) servletRequest.getSession(false).getAttribute("userId");
+
+        commentService.deleteCommentById(scheduleId, commentId, userId);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/com/example/schedulerapp/service/CommentService.java
+++ b/src/main/java/com/example/schedulerapp/service/CommentService.java
@@ -14,6 +14,6 @@ public interface CommentService {
 
     CommentResponseDto updateCommentById(Long scheduleId, Long commentId, CommentRequestDto requestDto, Long userId);
 
-    void deleteCommentById(Long scheduleId, Long commentId);
+    void deleteCommentById(Long scheduleId, Long commentId, Long userId);
 
 }

--- a/src/main/java/com/example/schedulerapp/service/CommentServiceJPA.java
+++ b/src/main/java/com/example/schedulerapp/service/CommentServiceJPA.java
@@ -73,14 +73,18 @@ public class CommentServiceJPA implements CommentService {
     }
 
     @Override
-    public void deleteCommentById(Long scheduleId, Long commentId) {
+    public void deleteCommentById(Long scheduleId, Long commentId, Long userId) {
 
-        scheduleRepository.findByIdOrElseThrow(scheduleId);
+        CommentEntity findComment = commentRepository.findByIdCommentOrElseThrow(commentId); // 댓글 조회
 
-        CommentEntity findComment = commentRepository.findByIdCommentOrElseThrow(commentId);
-
+        // 조회한 댓글이 조회한 일정에 속하는지 확인 절차
         if (!findComment.getSchedule().getId().equals(scheduleId)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Does not exist Comment");
+        }
+
+        // 댓글 작성자가 본인인지 확인
+        if (!findComment.getUser().getId().equals(userId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You can only modify your own comment.");
         }
 
         commentRepository.delete(findComment);


### PR DESCRIPTION
- Controller 레이어
> - deleteCommentById 매개변수로 HttpServletRequest 추가
> - 서블릿의 getAttribute 를 통해 userId 값 얻은 후
> - 서비스 레이어에 요청 DTO 와 함께 전달

- Service 레이어
> - 매개변수로 받은 유저 식별자 Id(로그인 세션 정보)로 유저 정보 찾은 후 댓글 작성 데이터에 기록된 유저 정보와 비교
> - 일치: 댓글 삭제 로직 진행 / 불일치: 403 FORBIDDEN 에러