### PR TITLE
Refactor: 일정 조회 시 각 일정에 저장된 댓글 리스트를 포함하여 조회되도록 수정

### DIFF
--- a/src/main/java/com/example/schedulerapp/dto/commentDto/CommentEntityDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/commentDto/CommentEntityDto.java
@@ -1,0 +1,16 @@
+package com.example.schedulerapp.dto.commentDto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentEntityDto {
+
+    private Long id;
+    private String comment;
+    private String username;
+    private Long scheduleId;
+
+}

--- a/src/main/java/com/example/schedulerapp/dto/scheduleDto/ScheduleTimeIncludedResponseDto.java
+++ b/src/main/java/com/example/schedulerapp/dto/scheduleDto/ScheduleTimeIncludedResponseDto.java
@@ -1,11 +1,16 @@
 package com.example.schedulerapp.dto.scheduleDto;
 
+import com.example.schedulerapp.dto.commentDto.CommentEntityDto;
+import com.example.schedulerapp.entity.CommentEntity;
 import com.example.schedulerapp.entity.Schedule;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
+@AllArgsConstructor
 public class ScheduleTimeIncludedResponseDto {
     private final Long id;
 
@@ -19,18 +24,7 @@ public class ScheduleTimeIncludedResponseDto {
 
     private final LocalDateTime modifiedAt;
 
-
-    public ScheduleTimeIncludedResponseDto
-            (Long id, String title, String contents, String username,
-            LocalDateTime createdAt, LocalDateTime modifiedAt)
-    {
-        this.id = id;
-        this.title = title;
-        this.contents = contents;
-        this.username = username;
-        this.createdAt = createdAt;
-        this.modifiedAt = modifiedAt;
-    }
+    private final List<CommentEntityDto> comments;
 
     public static ScheduleTimeIncludedResponseDto toDto (Schedule schedule) {
         return new ScheduleTimeIncludedResponseDto(
@@ -39,7 +33,8 @@ public class ScheduleTimeIncludedResponseDto {
                 schedule.getContents(),
                 schedule.getUser().getName(),
                 schedule.getCreatedAt(),
-                schedule.getModifiedAt()
+                schedule.getModifiedAt(),
+                schedule.getComments().stream().map(CommentEntity::toDto).toList()
         );
     }
 }

--- a/src/main/java/com/example/schedulerapp/entity/CommentEntity.java
+++ b/src/main/java/com/example/schedulerapp/entity/CommentEntity.java
@@ -1,6 +1,7 @@
 package com.example.schedulerapp.entity;
 
 
+import com.example.schedulerapp.dto.commentDto.CommentEntityDto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -39,4 +40,14 @@ public class CommentEntity extends BaseTimeEntity {
     public void updateComment (String comment) {
         this.comment = comment;
     }
+
+    public CommentEntityDto toDto() {
+        return new CommentEntityDto(
+                this.id,
+                this.comment,
+                this.user.getName(),
+                this.schedule.getId()
+        );
+    }
+
 }

--- a/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
+++ b/src/main/java/com/example/schedulerapp/service/ScheduleServiceJPA.java
@@ -1,6 +1,7 @@
 package com.example.schedulerapp.service;
 
 import com.example.schedulerapp.dto.scheduleDto.*;
+import com.example.schedulerapp.entity.CommentEntity;
 import com.example.schedulerapp.entity.Schedule;
 import com.example.schedulerapp.entity.User;
 import com.example.schedulerapp.repository.ScheduleRepository;
@@ -61,7 +62,15 @@ public class ScheduleServiceJPA implements ScheduleService {
     public ScheduleTimeIncludedResponseDto findByIdSchedule(Long id) {
         Schedule findSchedule = scheduleRepository.findByIdOrElseThrow(id);
 
-        return new ScheduleTimeIncludedResponseDto(findSchedule.getId(), findSchedule.getTitle(), findSchedule.getContents(), findSchedule.getUser().getName(), findSchedule.getCreatedAt(), findSchedule.getModifiedAt());
+        return new ScheduleTimeIncludedResponseDto(
+                findSchedule.getId(),
+                findSchedule.getTitle(),
+                findSchedule.getContents(),
+                findSchedule.getUser().getName(),
+                findSchedule.getCreatedAt(),
+                findSchedule.getModifiedAt(),
+                findSchedule.getComments().stream().map(CommentEntity::toDto).toList()
+        );
     }
 
     @Transactional


### PR DESCRIPTION
CommentEntity, CommentEntityDto:
- 댓글 리스트를 응답 결과로 보여주기 위한 메서드 생성

ScheduleTimeIncludedResponseDto:
- 댓글들을 List 로 선언 후 기존 응답 DTO 로 활용한 메서드에도 추가

ScheduleServiceJPA
- findByIdSchedule 메서드에 Comments 값 추가